### PR TITLE
chore: optimize upper fn and code cleanup

### DIFF
--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -699,7 +699,7 @@ fn create_iter<'a, R: Transaction>(
             .unwrap_or(Bound::Unbounded);
         reader.iter_from(tree, start, true)
     } else {
-        reader.iter_from(tree, Bound::Included(&prefix), false)
+        reader.iter_from(tree, Bound::Included(prefix), false)
     }
 }
 

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -748,7 +748,7 @@ where
         let scanner = Scanner::new(
             iter,
             vec![],
-            prefix.clone(),
+            prefix,
             filter.desc,
             filter.since,
             filter.until,
@@ -772,7 +772,7 @@ where
             let scanner = Scanner::new(
                 iter,
                 vec![],
-                prefix.clone(),
+                prefix,
                 filter.desc,
                 filter.since,
                 filter.until,
@@ -814,7 +814,7 @@ where
                 let scanner = Scanner::new(
                     iter,
                     vec![],
-                    prefix.clone(),
+                    prefix,
                     filter.desc,
                     filter.since,
                     filter.until,
@@ -875,7 +875,7 @@ where
                     let scanner = Scanner::new(
                         iter,
                         key.as_bytes().to_vec(),
-                        prefix.clone(),
+                        prefix,
                         filter.desc,
                         filter.since,
                         filter.until,
@@ -898,7 +898,7 @@ where
                 let scanner = Scanner::new(
                     iter,
                     key.as_bytes().to_vec(),
-                    prefix.clone(),
+                    prefix,
                     filter.desc,
                     filter.since,
                     filter.until,
@@ -956,7 +956,7 @@ where
             let scanner = Scanner::new(
                 iter,
                 key.as_bytes().to_vec(),
-                prefix.clone(),
+                prefix,
                 filter.desc,
                 filter.since,
                 filter.until,
@@ -995,7 +995,7 @@ where
                 let scanner = Scanner::new(
                     iter,
                     vec![],
-                    prefix.clone(),
+                    prefix,
                     filter.desc,
                     filter.since,
                     filter.until,


### PR DESCRIPTION
This PR optimized `upper` fn of db crate by using `iter() / rposition()` to find the index of the last element that is less than u8::MAX and truncate the vec, rather than repeatedly popping and pushing elements in a loop. And some unnecessary ref and clone calls are removed also.