### PR TITLE
fix: subscription_id length validation

### DIFF
--- a/relay/src/message.rs
+++ b/relay/src/message.rs
@@ -339,6 +339,7 @@ pub enum Subscribed {
     Ok,
     Overlimit,
     Duplicate,
+    InvalidIdLength,
 }
 
 #[derive(Message, Clone, Debug)]

--- a/relay/src/server.rs
+++ b/relay/src/server.rs
@@ -143,6 +143,12 @@ impl Handler<ClientMessage> for Server {
                                         session_id,
                                         OutgoingMessage::notice("This subscription already exists"),
                                     );
+                                },
+                                Subscribed::InvalidIdLength => {
+                                    act.send_to_client(
+                                        session_id,
+                                        OutgoingMessage::notice("Subscription id should be non-empty string of max length 64 chars"),
+                                    );
                                 }
                             },
                             Err(_err) => {


### PR DESCRIPTION
According to NIP-01, <subscription_id> is an arbitrary, non-empty string of max length 64 chars, otherwise, a malicious client may DoS the relay server memory by sending a large number of subscriptions with long id. This PR also optimized subscriptions hashmap by only storing the subscription filters, since the subscription id has been stored as the key already.