### PR TITLE
fix: kind should be 0~65535

### DIFF
--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -30,7 +30,7 @@ pub fn upper(mut key: Vec<u8>) -> Option<Vec<u8>> {
 }
 
 const MAX_TAG_VALUE_SIZE: usize = 255;
-const DB_VERSION: &str = "2";
+const DB_VERSION: &str = "3";
 
 #[derive(Clone)]
 pub struct Db {

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    key::{concat, concat_sep, encode_replace_key, u64_to_ver, IndexKey},
+    key::{concat, concat_sep, encode_replace_key, u16_to_ver, u64_to_ver, IndexKey},
     ArchivedEventIndex, Event, EventIndex, Filter, FromEventData, Stats,
 };
 use nostr_kv::{
@@ -65,6 +65,10 @@ pub struct Db {
 
 fn u64_from_bytes(bytes: &[u8]) -> Result<u64, Error> {
     Ok(u64::from_be_bytes(bytes.try_into()?))
+}
+
+fn u16_from_bytes(bytes: &[u8]) -> Result<u16, Error> {
+    Ok(u16::from_be_bytes(bytes.try_into()?))
 }
 
 // Get the latest seq from db
@@ -757,7 +761,7 @@ where
     ) -> Result<Self, Error> {
         let mut group = Group::new(filter.desc, false, false);
         for kind in filter.kinds.as_ref().unwrap().iter() {
-            let prefix = u64_to_ver(*kind);
+            let prefix = u16_to_ver(*kind);
             let iter = create_iter(reader, view, &prefix, filter.desc);
             let scanner = Scanner::new(
                 iter,
@@ -814,7 +818,7 @@ where
                         Ok(if k.len() == klen && k.starts_with(&s.prefix) {
                             // filter
                             if has_kind
-                                && !Filter::match_kind(kinds.as_ref(), u64_from_bytes(&v[8..16])?)
+                                && !Filter::match_kind(kinds.as_ref(), u16_from_bytes(&v[8..10])?)
                             {
                                 MatchResult::Continue
                             } else {
@@ -860,7 +864,7 @@ where
             // full key
             if key.len() == key_len * 2 {
                 for kind in kinds.iter() {
-                    let prefix: Vec<u8> = concat(&prefix, u64_to_ver(*kind));
+                    let prefix: Vec<u8> = concat(&prefix, u16_to_ver(*kind));
                     let iter = create_iter(reader, view, &prefix, filter.desc);
                     let scanner = Scanner::new(
                         iter,
@@ -901,7 +905,7 @@ where
                         };
                         Ok(if ok {
                             // check kind
-                            let kind = u64_from_bytes(&k[32..40])?;
+                            let kind = u16_from_bytes(&k[32..34])?;
                             if !clone_kinds.contains(&kind) {
                                 MatchResult::Continue
                             } else {

--- a/db/src/filter.rs
+++ b/db/src/filter.rs
@@ -45,7 +45,7 @@ pub struct Filter {
     pub authors: Option<Vec<String>>,
 
     /// a list of a kind numbers
-    pub kinds: Option<Vec<u64>>,
+    pub kinds: Option<Vec<u16>>,
 
     pub since: Option<u64>,
     pub until: Option<u64>,
@@ -76,7 +76,7 @@ impl FromStr for Filter {
 struct _Filter {
     pub ids: Option<Vec<String>>,
     pub authors: Option<Vec<String>>,
-    pub kinds: Option<Vec<u64>>,
+    pub kinds: Option<Vec<u16>>,
     pub since: Option<u64>,
     pub until: Option<u64>,
     pub limit: Option<u64>,
@@ -221,7 +221,7 @@ impl Filter {
         })
     }
 
-    pub fn match_kind(kinds: Option<&Vec<u64>>, kind: u64) -> bool {
+    pub fn match_kind(kinds: Option<&Vec<u16>>, kind: u16) -> bool {
         kinds.map_or(true, |ks| ks.contains(&kind))
     }
 
@@ -328,7 +328,7 @@ mod tests {
             "until": 5,
             "since": 3,
             "limit": 6,
-            "#d": ["ab", "cd", "12"], 
+            "#d": ["ab", "cd", "12"],
             "#f": ["ab", "cd", "12", "ab"],
             "#b": [],
             "search": "abc",

--- a/db/tests/db.rs
+++ b/db/tests/db.rs
@@ -11,7 +11,7 @@ pub struct MyEvent {
     id: Vec<u8>,
     pubkey: Vec<u8>,
     created_at: u64,
-    kind: u64,
+    kind: u16,
     tags: Vec<Vec<String>>,
     content: String,
     sig: Vec<u8>,
@@ -644,7 +644,7 @@ pub fn test_query_author_kinds() -> Result<()> {
             MyEvent {
                 id: id(15, i),
                 pubkey: author(20),
-                kind: 1000 + (i / 2) as u64,
+                kind: 1000 + (i / 2) as u16,
                 content: "author 2 kind".to_owned(),
                 created_at: i as u64 * 1000,
                 ..Default::default()
@@ -659,7 +659,7 @@ pub fn test_query_author_kinds() -> Result<()> {
             MyEvent {
                 id: id(16, i),
                 pubkey: author(20),
-                kind: 1000 + (i / 2) as u64,
+                kind: 1000 + (i / 2) as u16,
                 content: "author 2 kind".to_owned(),
                 created_at: 100_000 + i as u64 * 1000,
                 ..Default::default()
@@ -733,7 +733,7 @@ pub fn test_query_authors() -> Result<()> {
             MyEvent {
                 id: id(25, i),
                 pubkey: author(20),
-                kind: 1 + i as u64,
+                kind: 1 + i as u16,
                 content: "author 2 kind".to_owned(),
                 created_at: i as u64 * 1000,
                 tags: vec![vec!["t".to_owned(), "query tag1".to_owned()]],
@@ -875,7 +875,7 @@ pub fn test_query_tag() -> Result<()> {
             MyEvent {
                 id: id(10, i),
                 pubkey: author(30),
-                kind: i as u64,
+                kind: i as u16,
                 content: "author 3 tag".to_owned(),
                 created_at: i as u64 * 1000,
                 tags: vec![
@@ -896,7 +896,7 @@ pub fn test_query_tag() -> Result<()> {
             MyEvent {
                 id: id(25, i),
                 pubkey: author(20),
-                kind: i as u64,
+                kind: i as u16,
                 content: "author 2 kind".to_owned(),
                 created_at: i as u64 * 1000,
                 tags: vec![
@@ -1007,7 +1007,7 @@ pub fn test_query_kinds() -> Result<()> {
             MyEvent {
                 id: id(15, i),
                 pubkey: author(20),
-                kind: 1000 + (i / 2) as u64,
+                kind: 1000 + (i / 2) as u16,
                 content: "author 2 kind".to_owned(),
                 created_at: i as u64 * 1000,
                 ..Default::default()
@@ -1022,7 +1022,7 @@ pub fn test_query_kinds() -> Result<()> {
             MyEvent {
                 id: id(16, i),
                 pubkey: author(20),
-                kind: 1000 + (i / 2) as u64,
+                kind: 1000 + (i / 2) as u16,
                 content: "author 2 kind".to_owned(),
                 created_at: 100_000 + i as u64 * 1000,
                 ..Default::default()
@@ -1081,7 +1081,7 @@ pub fn test_query_ids() -> Result<()> {
             MyEvent {
                 id: id(10, i),
                 pubkey: author(30),
-                kind: i as u64,
+                kind: i as u16,
                 content: "author 3 tag".to_owned(),
                 created_at: i as u64 * 1000,
                 tags: vec![vec!["t".to_owned(), "query tag".to_owned()]],

--- a/extensions/src/rate_limiter.rs
+++ b/extensions/src/rate_limiter.rs
@@ -98,7 +98,7 @@ impl EventQuota {
         }
         if let Some(list) = &self.kinds {
             for range in list {
-                if range.contains(event.kind()) {
+                if range.contains(event.kind() as u64) {
                     return true;
                 }
             }


### PR DESCRIPTION
According to NIP-01, field `kind` should be a integer between 0 and 65535, however we didn't check this in current code, this PR try to fix it by changing field type from `u64` to `u16`, this change also reduce the storage size. Please note this change is incompatible with old data, so we need to migrate the data. I'm not quite sure how migration works, is it done by command export / import?