### PR TITLE
refactor: use array for id, pubkey and sig

### DIFF
--- a/db/src/key.rs
+++ b/db/src/key.rs
@@ -105,7 +105,7 @@ pub fn u16_to_ver(num: u16) -> Vec<u8> {
 
 // Replaceable Events [NIP-16](https://nips.be/16)
 // Parameterized Replaceable Events [NIP-33](https://nips.be/33)
-pub fn encode_replace_key(kind: u16, pubkey: &Vec<u8>, tags: &[Vec<String>]) -> Option<Vec<u8>> {
+pub fn encode_replace_key(kind: u16, pubkey: &[u8; 32], tags: &[Vec<String>]) -> Option<Vec<u8>> {
     if kind == 0 || kind == 3 || kind == 41 || (10_000..20_000).contains(&kind) {
         let k = u16_to_ver(kind);
         let p: &[u8] = pubkey.as_ref();
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     fn replace_key() {
         let tags = vec![vec!["d".to_owned(), "m".to_owned()]];
-        let pubkey = vec![1u8; 32];
+        let pubkey = [1u8; 32];
         let time = u64_to_ver(10);
         let empty: Vec<u8> = vec![];
 

--- a/db/tests/db.rs
+++ b/db/tests/db.rs
@@ -6,15 +6,15 @@ use std::time::Duration;
 
 type Result<T, E = Error> = core::result::Result<T, E>;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct MyEvent {
-    id: Vec<u8>,
-    pubkey: Vec<u8>,
+    id: [u8; 32],
+    pubkey: [u8; 32],
     created_at: u64,
     kind: u16,
     tags: Vec<Vec<String>>,
     content: String,
-    sig: Vec<u8>,
+    sig: [u8; 64],
 }
 
 impl MyEvent {
@@ -22,6 +22,20 @@ impl MyEvent {
         let mut e: Event = self.into();
         e.build_note_words();
         e
+    }
+}
+
+impl Default for MyEvent {
+    fn default() -> Self {
+        Self {
+            id: [0; 32],
+            pubkey: [0; 32],
+            created_at: 0,
+            kind: 0,
+            tags: Vec::new(),
+            content: String::new(),
+            sig: [0; 64],
+        }
     }
 }
 
@@ -48,15 +62,22 @@ pub fn create_db(t: &str) -> Result<Db> {
     Db::open(dir.path())
 }
 
-const PREFIX: [u8; 29] = [0; 29];
 const PER_NUM: u8 = 30;
 
-fn author(index: u8) -> Vec<u8> {
-    [PREFIX.to_vec(), vec![1u8, 0, index]].concat()
+fn author(index: u8) -> [u8; 32] {
+    let mut pubkey = [0; 32];
+    pubkey[29] = 1;
+    pubkey[30] = 0;
+    pubkey[31] = index;
+    pubkey
 }
 
-fn id(p: u8, index: u8) -> Vec<u8> {
-    [PREFIX.to_vec(), vec![1u8, p, index]].concat()
+fn id(p: u8, index: u8) -> [u8; 32] {
+    let mut id = [0; 32];
+    id[29] = 1;
+    id[30] = p;
+    id[31] = index;
+    id
 }
 
 #[test]

--- a/extensions/src/auth.rs
+++ b/extensions/src/auth.rs
@@ -383,13 +383,13 @@ mod tests {
 
         let event = Event::create(&key_pair, 0, 1, vec![], "".to_owned())?;
         let event = Event::new(
-            event.id().to_vec(),
-            event.pubkey().to_vec(),
+            event.id().clone(),
+            event.pubkey().clone(),
             event.created_at(),
             2,
             vec![],
             "".to_owned(),
-            event.sig().to_vec(),
+            event.sig().clone(),
         )?;
         framed
             .send(ws::Message::Text(

--- a/extensions/src/rate_limiter.rs
+++ b/extensions/src/rate_limiter.rs
@@ -299,8 +299,9 @@ mod tests {
 
     #[test]
     fn hit() -> Result<()> {
-        let event =
-            Event::from_str(r#"{"kind":1, "id": "", "pubkey": "", "created_at": 1, "sig": ""}"#)?;
+        let event = Event::from_str(
+            r#"{"kind":1, "id": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "pubkey": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "created_at": 1, "sig": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}"#,
+        )?;
         let ip = "127.0.0.1".to_owned();
 
         let q = EventQuota {
@@ -325,8 +326,9 @@ mod tests {
         assert!(!q.hit(&event, &ip));
         // kinds
         assert!(q.hit(&event, &"127".to_owned()));
-        let event =
-            Event::from_str(r#"{"kind":101, "id": "", "pubkey": "", "created_at": 1, "sig": ""}"#)?;
+        let event = Event::from_str(
+            r#"{"kind":101, "id": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "pubkey": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "created_at": 1, "sig": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}"#,
+        )?;
         assert!(!q.hit(&event, &"127".to_owned()));
         Ok(())
     }


### PR DESCRIPTION
according to NIP-01, `id`, `pubkey` and `sig` are fixed length, this PR changed the fields type from vec to array, it should improve the performance of serialization/deserialization. Below is the result of micro benchmarks for `index_to_bytes` and `index_from_bytes` on my local env:

```log
event/index_to_bytes    time:   [739.60 ns 748.56 ns 760.29 ns]
                        thrpt:  [1.3153 Melem/s 1.3359 Melem/s 1.3521 Melem/s]
                 change:
                        time:   [-10.352% -8.4614% -6.3123%] (p = 0.00 < 0.05)
                        thrpt:  [+6.7376% +9.2436% +11.547%]
                        Performance has improved.

event/index_from_bytes  time:   [276.65 ns 279.34 ns 282.96 ns]
                        thrpt:  [3.5341 Melem/s 3.5799 Melem/s 3.6146 Melem/s]
                 change:
                        time:   [-21.716% -19.160% -16.924%] (p = 0.00 < 0.05)
                        thrpt:  [+20.371% +23.701% +27.740%]
                        Performance has improved.
```