### PR TITLE
refactor: use empty vec for Filter fields

### DIFF
--- a/db/tests/db.rs
+++ b/db/tests/db.rs
@@ -486,7 +486,7 @@ pub fn test_events_delegator() -> Result<()> {
 
     db.batch_put(&events)?;
     let filter = Filter {
-        authors: Some(vec![hex::encode(author(1))].into()),
+        authors: vec![hex::encode(author(1))].into(),
         ..Default::default()
     };
     let e1 = all(&db, &filter)?;
@@ -494,7 +494,7 @@ pub fn test_events_delegator() -> Result<()> {
 
     // query by tag
     let filter = Filter {
-        authors: Some(vec![hex::encode(author(1))].into()),
+        authors: vec![hex::encode(author(1))].into(),
         tags: HashMap::from([(
             "t".to_string().into_bytes(),
             vec!["query tag".to_string().into_bytes()].into(),
@@ -517,7 +517,7 @@ pub fn test_events_delegator() -> Result<()> {
 
     db.batch_put(&events)?;
     let filter = Filter {
-        authors: Some(vec![hex::encode(author(1))].into()),
+        authors: vec![hex::encode(author(1))].into(),
         ..Default::default()
     };
     let e1 = all(&db, &filter)?;
@@ -636,7 +636,7 @@ pub fn test_query_authors_by_prefix() -> Result<()> {
 
     // prefix break time range
     let filter = Filter {
-        authors: Some(vec![hex::encode(author(250))[0..63].to_string()].into()),
+        authors: vec![hex::encode(author(250))[0..63].to_string()].into(),
         since: Some(2),
         until: Some(4),
         desc: true,
@@ -691,8 +691,8 @@ pub fn test_query_author_kinds() -> Result<()> {
     db.batch_put(events)?;
 
     let filter = Filter {
-        authors: Some(vec![hex::encode(author(20))].into()),
-        kinds: Some(vec![1000, 1001].into()),
+        authors: vec![hex::encode(author(20))].into(),
+        kinds: vec![1000, 1001].into(),
         desc: false,
         ..Default::default()
     };
@@ -707,8 +707,8 @@ pub fn test_query_author_kinds() -> Result<()> {
     }
     // rev
     let filter = Filter {
-        authors: Some(vec![hex::encode(author(20))].into()),
-        kinds: Some(vec![1000, 1001].into()),
+        authors: vec![hex::encode(author(20))].into(),
+        kinds: vec![1000, 1001].into(),
         desc: true,
         ..Default::default()
     };
@@ -719,8 +719,8 @@ pub fn test_query_author_kinds() -> Result<()> {
     }
     // prefix
     let filter = Filter {
-        authors: Some(vec![hex::encode(author(20))[0..63].to_string()].into()),
-        kinds: Some(vec![1000, 1001].into()),
+        authors: vec![hex::encode(author(20))[0..63].to_string()].into(),
+        kinds: vec![1000, 1001].into(),
         desc: true,
         ..Default::default()
     };
@@ -766,7 +766,7 @@ pub fn test_query_authors() -> Result<()> {
     db.batch_put(events)?;
 
     let filter = Filter {
-        authors: Some(vec![hex::encode(author(10))].into()),
+        authors: vec![hex::encode(author(10))].into(),
         desc: false,
         ..Default::default()
     };
@@ -774,12 +774,12 @@ pub fn test_query_authors() -> Result<()> {
     assert_eq!(e1.0.len(), PER_NUM as usize);
 
     let filter = Filter {
-        authors: Some(vec![hex::encode(author(20))].into()),
+        authors: vec![hex::encode(author(20))].into(),
         tags: HashMap::from([(
             "t".to_string().into_bytes(),
             vec!["query tag1".to_string().into_bytes()].into(),
         )]),
-        kinds: Some(vec![1, 2, 3].into()),
+        kinds: vec![1, 2, 3].into(),
         desc: true,
         ..Default::default()
     };
@@ -967,7 +967,7 @@ pub fn test_query_tag() -> Result<()> {
             "t".to_string().into_bytes(),
             vec!["query tag".to_string().into_bytes()].into(),
         )]),
-        kinds: Some(vec![1, 2, 3].into()),
+        kinds: vec![1, 2, 3].into(),
         desc: true,
         ..Default::default()
     };
@@ -979,7 +979,7 @@ pub fn test_query_tag() -> Result<()> {
             "t".to_string().into_bytes(),
             vec!["query tag1".to_string().into_bytes()].into(),
         )]),
-        kinds: Some(vec![1, 2, 3].into()),
+        kinds: vec![1, 2, 3].into(),
         desc: true,
         ..Default::default()
     };
@@ -991,8 +991,8 @@ pub fn test_query_tag() -> Result<()> {
             "t".to_string().into_bytes(),
             vec!["query tag".to_string().into_bytes()].into(),
         )]),
-        kinds: Some(vec![1, 2, 3].into()),
-        authors: Some(vec![hex::encode(author(20))].into()),
+        kinds: vec![1, 2, 3].into(),
+        authors: vec![hex::encode(author(20))].into(),
         desc: true,
         ..Default::default()
     };
@@ -1054,7 +1054,7 @@ pub fn test_query_kinds() -> Result<()> {
     db.batch_put(events)?;
 
     let filter = Filter {
-        kinds: Some(vec![1001, 1002, 1003].into()),
+        kinds: vec![1001, 1002, 1003].into(),
         desc: false,
         ..Default::default()
     };
@@ -1064,7 +1064,7 @@ pub fn test_query_kinds() -> Result<()> {
     assert_eq!(e1.0[1].kind(), 1001);
 
     let filter = Filter {
-        kinds: Some(vec![1000, 1001, 1002].into()),
+        kinds: vec![1000, 1001, 1002].into(),
         desc: true,
         ..Default::default()
     };
@@ -1114,7 +1114,7 @@ pub fn test_query_ids() -> Result<()> {
     db.batch_put(events)?;
 
     let filter = Filter {
-        ids: Some(vec![hex::encode(id(prefix, 0))].into()),
+        ids: vec![hex::encode(id(prefix, 0))].into(),
         desc: false,
         ..Default::default()
     };
@@ -1123,14 +1123,12 @@ pub fn test_query_ids() -> Result<()> {
     assert_eq!(e1.0[0].id(), &id(prefix, 0));
 
     let filter = Filter {
-        ids: Some(
-            vec![
-                hex::encode(id(prefix, 2)),
-                hex::encode(id(prefix, 4)),
-                hex::encode(id(prefix, 3)),
-            ]
-            .into(),
-        ),
+        ids: vec![
+            hex::encode(id(prefix, 2)),
+            hex::encode(id(prefix, 4)),
+            hex::encode(id(prefix, 3)),
+        ]
+        .into(),
         desc: false,
         ..Default::default()
     };
@@ -1142,14 +1140,12 @@ pub fn test_query_ids() -> Result<()> {
 
     // desc
     let filter = Filter {
-        ids: Some(
-            vec![
-                hex::encode(id(prefix, 2)),
-                hex::encode(id(prefix, 4)),
-                hex::encode(id(prefix, 3)),
-            ]
-            .into(),
-        ),
+        ids: vec![
+            hex::encode(id(prefix, 2)),
+            hex::encode(id(prefix, 4)),
+            hex::encode(id(prefix, 3)),
+        ]
+        .into(),
         desc: true,
         ..Default::default()
     };
@@ -1161,14 +1157,12 @@ pub fn test_query_ids() -> Result<()> {
 
     // desc
     let filter = Filter {
-        ids: Some(
-            vec![
-                hex::encode(id(prefix, 2)),
-                hex::encode(id(prefix, 4)),
-                hex::encode(id(prefix, 3)),
-            ]
-            .into(),
-        ),
+        ids: vec![
+            hex::encode(id(prefix, 2)),
+            hex::encode(id(prefix, 4)),
+            hex::encode(id(prefix, 3)),
+        ]
+        .into(),
         desc: true,
         ..Default::default()
     };
@@ -1180,7 +1174,7 @@ pub fn test_query_ids() -> Result<()> {
 
     // prefix
     let filter = Filter {
-        ids: Some(vec![hex::encode(id(prefix, 0))[0..62].to_string()].into()),
+        ids: vec![hex::encode(id(prefix, 0))[0..62].to_string()].into(),
         desc: true,
         ..Default::default()
     };
@@ -1189,7 +1183,7 @@ pub fn test_query_ids() -> Result<()> {
     assert_eq!(e1.0[0].id(), &id(prefix, 29));
 
     let filter = Filter {
-        ids: Some(vec![hex::encode(id(prefix, 0))[0..62].to_string()].into()),
+        ids: vec![hex::encode(id(prefix, 0))[0..62].to_string()].into(),
         desc: false,
         ..Default::default()
     };
@@ -1198,7 +1192,7 @@ pub fn test_query_ids() -> Result<()> {
     assert_eq!(e1.0[0].id(), &id(prefix, 0));
 
     let filter = Filter {
-        ids: Some(vec![hex::encode(id(prefix, 0))[0..63].to_string()].into()),
+        ids: vec![hex::encode(id(prefix, 0))[0..63].to_string()].into(),
         desc: true,
         ..Default::default()
     };
@@ -1207,20 +1201,18 @@ pub fn test_query_ids() -> Result<()> {
     assert_eq!(e1.0[0].id(), &id(prefix, 15));
 
     let filter = Filter {
-        ids: Some(
-            vec![
-                hex::encode(id(10, 1)),
-                hex::encode(id(10, 2)),
-                hex::encode(id(10, 3)),
-            ]
-            .into(),
-        ),
-        authors: Some(vec![hex::encode(author(30))].into()),
+        ids: vec![
+            hex::encode(id(10, 1)),
+            hex::encode(id(10, 2)),
+            hex::encode(id(10, 3)),
+        ]
+        .into(),
+        authors: vec![hex::encode(author(30))].into(),
         tags: HashMap::from([(
             "t".to_string().into_bytes(),
             vec!["query tag".to_string().into_bytes()].into(),
         )]),
-        kinds: Some(vec![1, 2, 3, 4].into()),
+        kinds: vec![1, 2, 3, 4].into(),
         desc: true,
         ..Default::default()
     };
@@ -1228,20 +1220,18 @@ pub fn test_query_ids() -> Result<()> {
     assert_eq!(e1.0.len(), 3);
 
     let filter = Filter {
-        ids: Some(
-            vec![
-                hex::encode(id(10, 1)),
-                hex::encode(id(10, 2)),
-                hex::encode(id(10, 3)),
-            ]
-            .into(),
-        ),
-        authors: Some(vec![hex::encode(author(20))].into()),
+        ids: vec![
+            hex::encode(id(10, 1)),
+            hex::encode(id(10, 2)),
+            hex::encode(id(10, 3)),
+        ]
+        .into(),
+        authors: vec![hex::encode(author(20))].into(),
         tags: HashMap::from([(
             "t".to_string().into_bytes(),
             vec!["query tag".to_string().into_bytes()].into(),
         )]),
-        kinds: Some(vec![1, 2, 3, 4].into()),
+        kinds: vec![1, 2, 3, 4].into(),
         desc: true,
         ..Default::default()
     };
@@ -1323,20 +1313,18 @@ pub fn test_query_search() -> Result<()> {
     assert_eq!(e1.0.len(), PER_NUM as usize);
 
     let mut filter = Filter {
-        ids: Some(
-            vec![
-                hex::encode(id(10, 1)),
-                hex::encode(id(10, 2)),
-                hex::encode(id(10, 3)),
-            ]
-            .into(),
-        ),
-        authors: Some(vec![hex::encode(author(1))].into()),
+        ids: vec![
+            hex::encode(id(10, 1)),
+            hex::encode(id(10, 2)),
+            hex::encode(id(10, 3)),
+        ]
+        .into(),
+        authors: vec![hex::encode(author(1))].into(),
         tags: HashMap::from([(
             "t".to_string().into_bytes(),
             vec!["query tag".to_string().into_bytes()].into(),
         )]),
-        kinds: Some(vec![1, 2, 3, 4].into()),
+        kinds: vec![1, 2, 3, 4].into(),
         search: Some("my note".to_string()),
         desc: false,
         ..Default::default()

--- a/relay/src/message.rs
+++ b/relay/src/message.rs
@@ -75,10 +75,8 @@ impl ClientMessage {
                     // fill default limit
                     f.default_limit(limitation.max_limit);
                     check_max!(f.limit.unwrap(), limitation.max_limit);
-                    if let Some(ids) = &f.ids {
-                        for id in ids.iter() {
-                            check_min!(id.len(), limitation.min_prefix);
-                        }
+                    for id in f.ids.iter() {
+                        check_min!(id.len(), limitation.min_prefix);
                     }
                 }
             }

--- a/relay/src/subscriber.rs
+++ b/relay/src/subscriber.rs
@@ -165,7 +165,7 @@ mod tests {
                 subscription: Subscription {
                     id: 1.to_string(),
                     filters: vec![Filter {
-                        kinds: Some(vec![1000].into()),
+                        kinds: vec![1000].into(),
                         ..Default::default()
                     }],
                 },
@@ -179,7 +179,7 @@ mod tests {
                 subscription: Subscription {
                     id: "".to_string(),
                     filters: vec![Filter {
-                        kinds: Some(vec![1000].into()),
+                        kinds: vec![1000].into(),
                         ..Default::default()
                     }],
                 },
@@ -194,7 +194,7 @@ mod tests {
                     id: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefA"
                         .to_string(),
                     filters: vec![Filter {
-                        kinds: Some(vec![1000].into()),
+                        kinds: vec![1000].into(),
                         ..Default::default()
                     }],
                 },


### PR DESCRIPTION
I'd like to try to resolve issue https://github.com/rnostr/rnostr/issues/10 ,  by fixing it with two separate PRs, this is the first one, changed to use `vec` as the Filter fields, and related `Option#is_some` checking has been replaced by `Vec#is_empty`. Plan to change `Vec<String>` to `Vec<[u8; 32]` and remove string prefix match after this PR is accepted.