### PR TITLE
Add NIP-25

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A high-performance and scalable [nostr](https://github.com/nostr-protocol/nostr)
 - [x] NIP-16: Event Treatment
 - [x] NIP-20: Command Results
 - [x] NIP-22: Event `created_at` Limits
+- [x] NIP-25: Reactions
 - [x] NIP-26: Delegated Event Signing
 - [x] NIP-28: Public Chat
 - [x] NIP-33: Parameterized Replaceable Events

--- a/relay/src/setting.rs
+++ b/relay/src/setting.rs
@@ -24,7 +24,7 @@ fn default_version() -> String {
 }
 
 fn default_nips() -> Vec<u32> {
-    vec![1, 2, 4, 9, 11, 12, 15, 16, 20, 22, 26, 28, 33, 40]
+    vec![1, 2, 4, 9, 11, 12, 15, 16, 20, 22, 25, 26, 28, 33, 40]
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]


### PR DESCRIPTION
`rnostr` seems to accept reactions, however client that checks (default) relay information can't to send them to `rnostr`.