### PR TITLE
fix: Refactor event writing to use drain method instead of pop

### DIFF
--- a/relay/src/writer.rs
+++ b/relay/src/writer.rs
@@ -38,7 +38,7 @@ impl Writer {
         if !self.events.is_empty() {
             let start = Instant::now();
             let mut writer = self.db.writer()?;
-            while let Some(event) = self.events.pop() {
+            for event in self.events.drain(..) {
                 let res = self.db.put(&mut writer, &event.event);
                 debug!(
                     "write event: {} {} {:?}",


### PR DESCRIPTION
The Writer accumulates events in a Vec across each 100ms write interval, then drains via `self.events.pop()`. `Vec::pop()` removes from the back, so events queued within a single interval are written to the DB and dispatched to subscribers in reverse arrival order.

For most workloads this is invisible — clients don't typically depend on per-publisher delivery order for events arriving within the same flush window. It breaks any protocol with sequence-number or causal ordering between adjacent events from the same publisher: under burst publishing, subscribers receive event N+1 before event N.

Replace `pop()` with `drain(..)` so the batch flushes in FIFO order. Same single-threaded write path, same batching for LMDB commit efficiency — only the iteration direction changes.