### PR TITLE
Version Bump 0.4.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rnostr"
-version = "0.4.8"
+version = "0.4.9"
 description = "A high-performance and scalable nostr relay."
 keywords = ["nostr", "nostr-relay"]
 edition.workspace = true
@@ -20,8 +20,8 @@ clap = { version = "4.5.16", features = ["derive"] }
 clio = { version = "0.3.5", features = ["clap-parse"] }
 indicatif = "0.17.8"
 nostr-db = { version = "0.4.5", path = "./db", features = ["search"] }
-nostr-relay = { version = "0.4.8", path = "./relay", features = ["search"] }
-nostr-extensions = { version = "0.4.8", path = "./extensions" }
+nostr-relay = { version = "0.4.9", path = "./relay", features = ["search"] }
+nostr-extensions = { version = "0.4.9", path = "./extensions" }
 rayon = "1.10.0"
 thiserror = "1.0.63"
 tracing = "0.1.40"

--- a/extensions/Cargo.toml
+++ b/extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostr-extensions"
-version = "0.4.8"
+version = "0.4.9"
 description = "Nostr relay extensions."
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ authors.workspace = true
 
 [dependencies]
 
-nostr-relay = { version = "0.4.8", path = "../relay" }
+nostr-relay = { version = "0.4.9", path = "../relay" }
 metrics = "0.23.0"
 metrics-exporter-prometheus = { version = "0.15.3", optional = true, default-features = false, features = [
     "push-gateway",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostr-relay"
-version = "0.4.8"
+version = "0.4.9"
 description = "A high-performance and scalable nostr relay library."
 keywords = ["nostr", "nostr-relay"]
 edition.workspace = true


### PR DESCRIPTION
Bumps `relay` and `extensions` crates and rnostr versions from `0.4.8` to `0.4.9`

@arronzhang Just trying to help get a release out with the change I added yesterday (thanks for the quick merge btw). Could you merge this then create the `v0.4.9` tag? Let me know if there is another way you'd like me to handle it. 